### PR TITLE
make creation of user_login_profile optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,6 @@
+locals {
+    create_login_profile = "${length(var.pgp_key) > 0 ? 1 : 0}"
+}
 
 resource "aws_iam_user" "this" {
   count         = "${length(var.user_names)}"
@@ -7,7 +10,7 @@ resource "aws_iam_user" "this" {
 }
 
 resource "aws_iam_user_login_profile" "this" {
-  count         = "${length(var.user_names)}"
+  count         = "${length(var.user_names) * local.create_login_profile}"
   user          = "${var.user_names[count.index]}"
   pgp_key       = "${var.pgp_key}"
   depends_on    = ["aws_iam_user.this"]

--- a/variables.tf
+++ b/variables.tf
@@ -10,4 +10,5 @@ variable "iam_policies" {
 
 variable "pgp_key" {
     description = "pgp for encrption of the user profile password generated"
-} 
+    default = ""
+}


### PR DESCRIPTION
This patch makes the creation of a login profile optional, This can be useful for users that should not be able to login to the AWS console